### PR TITLE
Remove Cloudinary signature

### DIFF
--- a/src/Traits/Support/InteractsWithCloudinary.php
+++ b/src/Traits/Support/InteractsWithCloudinary.php
@@ -79,11 +79,6 @@ trait InteractsWithCloudinary
             'cloud_name' => $cloud,
             'api_key' => $this->key ?? config('nova-cloudinary.default.key'),
             'username' => $username,
-            'timestamp' => $timestamp,
-            'signature' => hash(
-                algo: 'sha256',
-                data: "cloud_name={$cloud}&timestamp={$timestamp}&username={$username}{$secret}",
-            ),
         ];
     }
 }


### PR DESCRIPTION
The `signature` and `timestamp` parameters are not supported anymore and cause an error